### PR TITLE
Remove extraneous spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ There must be a space between the type identifier and the name of the protocol e
 @interface US2Class : NSObject <US2Delegate>
 {
     @private
-      UIView *_privateView;
+    UIView *_privateView;
 }
 
 @end


### PR DESCRIPTION
I don't think we're supposed to have two spaces indentation after visibility modifiers (`@private`)?
